### PR TITLE
reorder layer params

### DIFF
--- a/maplibre-kmp/src/commonMain/kotlin/dev/sargunv/maplibrekmp/compose/layer/BackgroundLayer.kt
+++ b/maplibre-kmp/src/commonMain/kotlin/dev/sargunv/maplibrekmp/compose/layer/BackgroundLayer.kt
@@ -26,6 +26,9 @@ import androidx.compose.runtime.key as composeKey
  * @param visible
  *   Whether the layer should be displayed.
  *
+ * @param opacity
+ *   Background opacity. A value in range `[0..1]`.
+ *
  * @param color
  *   Background color.
  *
@@ -35,10 +38,6 @@ import androidx.compose.runtime.key as composeKey
  *   Image to use for drawing image fills. For seamless patterns, image width and height must be a
  *   factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only
  *   at integer zoom levels.
- *
- * @param opacity
- *   Background opacity. A value in range `[0..1]`.
- *
  * */
 @Composable
 @Suppress("NOTHING_TO_INLINE")
@@ -47,9 +46,9 @@ public inline fun BackgroundLayer(
   minZoom: Float = 0.0f,
   maxZoom: Float = 24.0f,
   visible: Boolean = true,
+  opacity: Expression<Number> = const(1),
   color: Expression<Color> = const(Color.Black),
   pattern: Expression<TResolvedImage> = nil(),
-  opacity: Expression<Number> = const(1),
 ) {
   composeKey(id) {
     LayerNode(

--- a/maplibre-kmp/src/commonMain/kotlin/dev/sargunv/maplibrekmp/compose/layer/CircleLayer.kt
+++ b/maplibre-kmp/src/commonMain/kotlin/dev/sargunv/maplibrekmp/compose/layer/CircleLayer.kt
@@ -45,19 +45,6 @@ import io.github.dellisd.spatialk.geojson.Feature
  *   Sorts features within this layer in ascending order based on this value.
  *   Features with a higher sort key will appear above features with a lower sort key.
  *
- * @param radius
- *   Circles radius in dp. A value in range `[0..infinity)`.
- *
- * @param color
- *   Circles fill color.
- *
- * @param blur
- *   Amount to blur the circle. A value of `1` blurs the circle such that only the centerpoint has
- *   full opacity.
- *
- * @param opacity
- *   Circles opacity. A value in range `[0..1]`.
- *
  * @param translate
  *   The geometry's offset relative to the [translateAnchor]. Negative numbers indicate left and up,
  *   respectively.
@@ -67,22 +54,34 @@ import io.github.dellisd.spatialk.geojson.Feature
  *
  *   Ignored if [translate] is not set.
  *
- * @param pitchScale
- *   Scaling behavior of circles when the map is pitched. See [CirclePitchScale].
+ * @param opacity
+ *   Circles opacity. A value in range `[0..1]`.
  *
- * @param pitchAlignment
- *   Orientation of circles when the map is pitched. See [CirclePitchAlignment].
+ * @param color
+ *   Circles fill color.
+ *
+ * @param blur
+ *   Amount to blur the circle. A value of `1` blurs the circle such that only the centerpoint has
+ *   full opacity.
+ *
+ * @param radius
+ *   Circles radius in dp. A value in range `[0..infinity)`.
+ *
+ * @param strokeOpacity
+ *   Opacity of the circles' stroke.
+ *
+ * @param strokeColor
+ *   Circles' stroke color.
  *
  * @param strokeWidth
  *   Thickness of the circles' stroke in dp. Strokes are placed outside of the [radius].
  *   A value in range `[0..infinity)`.
  *
- * @param strokeColor
- *   Circles' stroke color.
+ * @param pitchScale
+ *   Scaling behavior of circles when the map is pitched. See [CirclePitchScale].
  *
- * @param strokeOpacity
- *   Opacity of the circles' stroke.
- *
+ * @param pitchAlignment
+ *   Orientation of circles when the map is pitched. See [CirclePitchAlignment].
  * */
 @Composable
 @Suppress("NOTHING_TO_INLINE")
@@ -95,17 +94,17 @@ public inline fun CircleLayer(
   filter: Expression<Boolean> = nil(),
   visible: Boolean = true,
   sortKey: Expression<Number> = nil(),
-  radius: Expression<Number> = const(5),
-  color: Expression<Color> = const(Color.Black),
-  blur: Expression<Number> = const(0),
-  opacity: Expression<Number> = const(1),
   translate: Expression<Point> = point(0, 0),
   translateAnchor: Expression<String> = const(TranslateAnchor.Map),
+  opacity: Expression<Number> = const(1),
+  color: Expression<Color> = const(Color.Black),
+  blur: Expression<Number> = const(0),
+  radius: Expression<Number> = const(5),
+  strokeOpacity: Expression<Number> = const(1),
+  strokeColor: Expression<Color> = const(Color.Black),
+  strokeWidth: Expression<Number> = const(0),
   pitchScale: Expression<String> = const(CirclePitchScale.Map),
   pitchAlignment: Expression<String> = const(CirclePitchAlignment.Viewport),
-  strokeWidth: Expression<Number> = const(0),
-  strokeColor: Expression<Color> = const(Color.Black),
-  strokeOpacity: Expression<Number> = const(1),
   noinline onClick: ((features: List<Feature>) -> Unit)? = null,
   noinline onLongClick: ((features: List<Feature>) -> Unit)? = null,
 ) {

--- a/maplibre-kmp/src/commonMain/kotlin/dev/sargunv/maplibrekmp/compose/layer/FillExtrusionLayer.kt
+++ b/maplibre-kmp/src/commonMain/kotlin/dev/sargunv/maplibrekmp/compose/layer/FillExtrusionLayer.kt
@@ -43,15 +43,6 @@ import androidx.compose.runtime.key as composeKey
  * @param visible
  *   Whether the layer should be displayed.
  *
- * @param opacity
- *   The opacity of the entire fill extrusion layer. This is rendered on a per-layer, not
- *   per-feature, basis, and data-driven styling is not available. A value in range `[0..1]`.
- *
- * @param color
- *   The base color of the extruded fill. The extrusion's surfaces will be shaded differently based
- *   on this color in combination with the root light settings. The alpha component of the specified
- *   color is ignored. Ignored if [pattern] is specified.
- *
  * @param translate
  *   The geometry's offset relative to the [translateAnchor]. Negative numbers indicate left and up
  *   (on the flat plane), respectively.
@@ -60,6 +51,15 @@ import androidx.compose.runtime.key as composeKey
  *   Frame of reference for offsetting geometry, see [TranslateAnchor].
  *
  *   Ignored if [translate] is not set.
+ *
+ * @param opacity
+ *   The opacity of the entire fill extrusion layer. This is rendered on a per-layer, not
+ *   per-feature, basis, and data-driven styling is not available. A value in range `[0..1]`.
+ *
+ * @param color
+ *   The base color of the extruded fill. The extrusion's surfaces will be shaded differently based
+ *   on this color in combination with the root light settings. The alpha component of the specified
+ *   color is ignored. Ignored if [pattern] is specified.
  *
  * @param pattern
  *   Name of image in sprite to use for drawing images on extruded fills. For seamless patterns,
@@ -89,10 +89,10 @@ public inline fun FillExtrusionLayer(
   maxZoom: Float = 24.0f,
   filter: Expression<Boolean> = nil(),
   visible: Boolean = true,
-  opacity: Expression<Number> = const(1.0),
-  color: Expression<Color> = const(Color.Black),
   translate: Expression<Point> = point(0.0, 0.0),
   translateAnchor: Expression<String> = const(TranslateAnchor.Map),
+  opacity: Expression<Number> = const(1.0),
+  color: Expression<Color> = const(Color.Black),
   pattern: Expression<TResolvedImage> = nil(),
   height: Expression<Number> = const(0.0),
   base: Expression<Number> = const(0.0),

--- a/maplibre-kmp/src/commonMain/kotlin/dev/sargunv/maplibrekmp/compose/layer/FillLayer.kt
+++ b/maplibre-kmp/src/commonMain/kotlin/dev/sargunv/maplibrekmp/compose/layer/FillLayer.kt
@@ -46,22 +46,6 @@ import io.github.dellisd.spatialk.geojson.Feature
  *   Sorts features within this layer in ascending order based on this value.
  *   Features with a higher sort key will appear above features with a lower sort key.
  *
- * @param antialias
- *   Whether or not the fill should be antialiased.
- *
- * @param opacity
- *   Fill opacity. A value in range `[0..1]`.
- *
- * @param color
- *   Fill color.
- *
- *   Ignored if [pattern] is specified.
- *
- * @param outlineColor
- *   The outline color of the fill. The outline is drawn at a hairline width.
- *
- *   Ignored if [antialias] is `false`.
- *
  * @param translate
  *   The geometry's offset relative to the [translateAnchor]. Negative numbers indicate left and up,
  *   respectively.
@@ -71,10 +55,26 @@ import io.github.dellisd.spatialk.geojson.Feature
  *
  *   Ignored if [translate] is not set.
  *
+ * @param opacity
+ *   Fill opacity. A value in range `[0..1]`.
+ *
+ * @param color
+ *   Fill color.
+ *
+ *   Ignored if [pattern] is specified.
+ *
  * @param pattern
  *   Image to use for drawing image fills. For seamless patterns, image width and height must be a
  *   factor of two (2, 4, 8, ..., 512). Note that zoom-dependent expressions will be evaluated only
  *   at integer zoom levels.
+ *
+ * @param antialias
+ *   Whether or not the fill should be antialiased.
+ *
+ * @param outlineColor
+ *   The outline color of the fill. The outline is drawn at a hairline width.
+ *
+ *   Ignored if [antialias] is `false`.
  * */
 @Composable
 @Suppress("NOTHING_TO_INLINE")
@@ -87,13 +87,13 @@ public inline fun FillLayer(
   filter: Expression<Boolean> = nil(),
   visible: Boolean = true,
   sortKey: Expression<Number> = nil(),
-  antialias: Expression<Boolean> = const(true),
-  opacity: Expression<Number> = const(1.0),
-  color: Expression<Color> = const(Color.Black),
-  outlineColor: Expression<Color> = color,
   translate: Expression<Point> = point(0.0, 0.0),
   translateAnchor: Expression<String> = const(TranslateAnchor.Map),
+  opacity: Expression<Number> = const(1.0),
+  color: Expression<Color> = const(Color.Black),
   pattern: Expression<TResolvedImage> = nil(),
+  antialias: Expression<Boolean> = const(true),
+  outlineColor: Expression<Color> = color,
   noinline onClick: ((features: List<Feature>) -> Unit)? = null,
   noinline onLongClick: ((features: List<Feature>) -> Unit)? = null,
 ) {

--- a/maplibre-kmp/src/commonMain/kotlin/dev/sargunv/maplibrekmp/compose/layer/HeatmapLayer.kt
+++ b/maplibre-kmp/src/commonMain/kotlin/dev/sargunv/maplibrekmp/compose/layer/HeatmapLayer.kt
@@ -41,6 +41,13 @@ import androidx.compose.runtime.key as composeKey
  * @param visible
  *   Whether the layer should be displayed.
  *
+ * @param color
+ *   Defines the color of each pixel based on its density value in a heatmap. Should be an
+ *   expression that uses [heatmapDensity] as input.
+ *
+ * @param opacity
+ *   The global opacity at which the heatmap layer will be drawn.
+ *
  * @param radius
  *   Radius of influence of one heatmap point in dp. Increasing the value makes the heatmap
  *   smoother, but less detailed. A value in the range of `[1..infinity)`.
@@ -54,13 +61,6 @@ import androidx.compose.runtime.key as composeKey
  *   Similar to [weight] but controls the intensity of the heatmap globally. Primarily used for
  *   adjusting the heatmap based on zoom level.
  *
- * @param color
- *   Defines the color of each pixel based on its density value in a heatmap. Should be an
- *   expression that uses [heatmapDensity] as input.
- *
- * @param opacity
- *   The global opacity at which the heatmap layer will be drawn.
- *
  * */
 @Composable
 @Suppress("NOTHING_TO_INLINE")
@@ -72,9 +72,6 @@ public inline fun HeatmapLayer(
   maxZoom: Float = 24.0f,
   filter: Expression<Boolean> = nil(),
   visible: Boolean = true,
-  radius: Expression<Number> = const(30),
-  weight: Expression<Number> = const(1),
-  intensity: Expression<Number> = const(1),
   color: Expression<Color> =
     interpolate(
       linear(),
@@ -87,6 +84,9 @@ public inline fun HeatmapLayer(
       1 to const(Color(0xFFFF0000)), // red
     ),
   opacity: Expression<Number> = const(1),
+  radius: Expression<Number> = const(30),
+  weight: Expression<Number> = const(1),
+  intensity: Expression<Number> = const(1),
   noinline onClick: ((features: List<Feature>) -> Unit)? = null,
   noinline onLongClick: ((features: List<Feature>) -> Unit)? = null,
 ) {

--- a/maplibre-kmp/src/commonMain/kotlin/dev/sargunv/maplibrekmp/compose/layer/HillshadeLayer.kt
+++ b/maplibre-kmp/src/commonMain/kotlin/dev/sargunv/maplibrekmp/compose/layer/HillshadeLayer.kt
@@ -30,6 +30,15 @@ import androidx.compose.runtime.key as composeKey
  * @param visible
  *   Whether the layer should be displayed.
  *
+ * @param shadowColor
+ *   The shading color of areas that face away from the light source.
+ *
+ * @param highlightColor
+ *   The shading color of areas that faces towards the light source.
+ *
+ * @param accentColor
+ *   The shading color used to accentuate rugged terrain like sharp cliffs and gorges.
+ *
  * @param illuminationDirection
  *   The direction of the light source used to generate the hillshading in degrees. A value in the
  *   range of `[0..360)`.
@@ -43,15 +52,6 @@ import androidx.compose.runtime.key as composeKey
  *
  * @param exaggeration
  *   Intensity of the hillshade. A value in the range of `[0..1]`.
- *
- * @param shadowColor
- *   The shading color of areas that face away from the light source.
- *
- * @param highlightColor
- *   The shading color of areas that faces towards the light source.
- *
- * @param accentColor
- *   The shading color used to accentuate rugged terrain like sharp cliffs and gorges.
  * */
 @Composable
 @Suppress("NOTHING_TO_INLINE")
@@ -61,12 +61,12 @@ public inline fun HillshadeLayer(
   minZoom: Float = 0.0f,
   maxZoom: Float = 24.0f,
   visible: Boolean = true,
-  illuminationDirection: Expression<Number> = const(355),
-  illuminationAnchor: Expression<String> = const(IlluminationAnchor.Viewport),
-  exaggeration: Expression<Number> = const(0.5),
   shadowColor: Expression<Color> = const(Color.Black),
   highlightColor: Expression<Color> = const(Color.White),
   accentColor: Expression<Color> = const(Color.Black),
+  illuminationDirection: Expression<Number> = const(355),
+  illuminationAnchor: Expression<String> = const(IlluminationAnchor.Viewport),
+  exaggeration: Expression<Number> = const(0.5),
   noinline onClick: ((features: List<Feature>) -> Unit)? = null,
   noinline onLongClick: ((features: List<Feature>) -> Unit)? = null,
 ) {

--- a/maplibre-kmp/src/commonMain/kotlin/dev/sargunv/maplibrekmp/compose/layer/LineLayer.kt
+++ b/maplibre-kmp/src/commonMain/kotlin/dev/sargunv/maplibrekmp/compose/layer/LineLayer.kt
@@ -43,31 +43,9 @@ import androidx.compose.runtime.key as composeKey
  * @param visible
  *   Whether the layer should be displayed.
  *
- * @param cap
- *   Display of line endings. See [StrokeCap].
- *
- * @param join
- *   Display of joined lines. See [StrokeJoin].
- *
- * @param miterLimit
- *   Limit at which to automatically convert to bevel join for sharp angles when
- *   [join] is [StrokeJoin.Miter].
- *
- * @param roundLimit
- *   Limit at which to automatically convert to miter join for sharp angles when
- *   [join] is [StrokeJoin.Round].
- *
  * @param sortKey
  *   Sorts features within this layer in ascending order based on this value.
  *   Features with a higher sort key will appear above features with a lower sort key.
- *
- * @param opacity
- *   Lines opacity. A value in range `[0..1]`.
- *
- * @param color
- *   Lines color.
- *
- *   Ignored if [pattern] is specified.
  *
  * @param translate
  *   The geometry's offset relative to the [translateAnchor]. Negative numbers indicate left and up,
@@ -78,20 +56,13 @@ import androidx.compose.runtime.key as composeKey
  *
  *   Ignored if [translate] is not set.
  *
- * @param width
- *   Thickness of the lines' stroke in dp. A value in range `[0..infinity)`.
+ * @param opacity
+ *   Lines opacity. A value in range `[0..1]`.
  *
- * @param gapWidth
- *   A value in range `[0..infinity)`. If not `0`, instead of one, two lines, each left and right of
- *   each line's actual path are drawn, with the given gap in dp in-between them.
+ * @param color
+ *   Lines color.
  *
- * @param offset
- *   The lines' offset. For linear features, a positive value offsets the line to the right,
- *   relative to the direction of the line, and a negative value to the left. For polygon features,
- *   a positive value results in an inset, and a negative value results in an outset.
- *
- * @param blur
- *   Blur applied to the lines, in dp. A value in range `0..infinity`.
+ *   Ignored if [pattern] is specified.
  *
  * @param dasharray
  *   Specifies the lengths of the alternating dashes and gaps that form the dash pattern. The
@@ -111,6 +82,35 @@ import androidx.compose.runtime.key as composeKey
  *   that specify `lineMetrics = true`.
  *
  *   Ignored if [pattern] or [dasharray] is specified.
+ *
+ * @param blur
+ *   Blur applied to the lines, in dp. A value in range `0..infinity`.
+ *
+ * @param width
+ *   Thickness of the lines' stroke in dp. A value in range `[0..infinity)`.
+ *
+ * @param gapWidth
+ *   A value in range `[0..infinity)`. If not `0`, instead of one, two lines, each left and right of
+ *   each line's actual path are drawn, with the given gap in dp in-between them.
+ *
+ * @param offset
+ *   The lines' offset. For linear features, a positive value offsets the line to the right,
+ *   relative to the direction of the line, and a negative value to the left. For polygon features,
+ *   a positive value results in an inset, and a negative value results in an outset.
+ *
+ * @param cap
+ *   Display of line endings. See [StrokeCap].
+ *
+ * @param join
+ *   Display of joined lines. See [StrokeJoin].
+ *
+ * @param miterLimit
+ *   Limit at which to automatically convert to bevel join for sharp angles when
+ *   [join] is [StrokeJoin.Miter].
+ *
+ * @param roundLimit
+ *   Limit at which to automatically convert to miter join for sharp angles when
+ *   [join] is [StrokeJoin.Round].
  * */
 @Composable
 @Suppress("NOTHING_TO_INLINE")
@@ -122,22 +122,22 @@ public inline fun LineLayer(
   maxZoom: Float = 24.0f,
   filter: Expression<Boolean> = nil(),
   visible: Boolean = true,
+  sortKey: Expression<Number> = nil(),
+  translate: Expression<Point> = point(0, 0),
+  translateAnchor: Expression<String> = const(TranslateAnchor.Map),
+  opacity: Expression<Number> = const(1),
+  color: Expression<Color> = const(Color.Black),
+  dasharray: Expression<List<Number>> = nil(),
+  pattern: Expression<TResolvedImage> = nil(),
+  gradient: Expression<Color> = nil(),
+  blur: Expression<Number> = const(0),
+  width: Expression<Number> = const(1),
+  gapWidth: Expression<Number> = const(0),
+  offset: Expression<Number> = const(0),
   cap: Expression<String> = const(StrokeCap.Butt),
   join: Expression<String> = const(StrokeJoin.Miter),
   miterLimit: Expression<Number> = const(2),
   roundLimit: Expression<Number> = const(1.05),
-  sortKey: Expression<Number> = nil(),
-  opacity: Expression<Number> = const(1),
-  color: Expression<Color> = const(Color.Black),
-  translate: Expression<Point> = point(0, 0),
-  translateAnchor: Expression<String> = const(TranslateAnchor.Map),
-  width: Expression<Number> = const(1),
-  gapWidth: Expression<Number> = const(0),
-  offset: Expression<Number> = const(0),
-  blur: Expression<Number> = const(0),
-  dasharray: Expression<List<Number>> = nil(),
-  pattern: Expression<TResolvedImage> = nil(),
-  gradient: Expression<Color> = nil(),
   noinline onClick: ((features: List<Feature>) -> Unit)? = null,
   noinline onLongClick: ((features: List<Feature>) -> Unit)? = null,
 ) {

--- a/maplibre-kmp/src/commonMain/kotlin/dev/sargunv/maplibrekmp/compose/layer/SymbolLayer.kt
+++ b/maplibre-kmp/src/commonMain/kotlin/dev/sargunv/maplibrekmp/compose/layer/SymbolLayer.kt
@@ -48,6 +48,11 @@ import androidx.compose.runtime.key as composeKey
  * @param visible
  *   Whether the layer should be displayed.
  *
+ * @param sortKey
+ *   Sorts features within this layer in ascending order based on this value.
+ *   Features with a higher sort key will appear above features with a lower sort key.
+ *
+ *
  * @param placement
  *   Symbol placement relative to its geometry. See [SymbolPlacement].
  *
@@ -61,101 +66,13 @@ import androidx.compose.runtime.key as composeKey
  *   layers that don't have enough padding in the vector tile to prevent collisions, or if it is a
  *   point symbol layer placed after a line symbol layer.
  *
- * @param sortKey
- *   Sorts features within this layer in ascending order based on this value.
- *   Features with a higher sort key will appear above features with a lower sort key.
- *
  * @param zOrder
  *   Determines whether overlapping symbols in the same layer are rendered in the order that they
  *   appear in the data source or by their y-position relative to the viewport. To control the order
  *   and prioritization of symbols otherwise, use [sortKey]. See [SymbolSortOrder].
  *
- * @param iconAllowOverlap
- *   If true, the icon will be visible even if it collides with other previously drawn symbols.
- *
- *   Ignored if [iconImage] is not specified, overridden by [iconOverlap], if specified.
- *
- * @param iconOverlap
- *   Controls whether to show an icon when it overlaps other symbols on the map.
- *   See [SymbolOverlap].
- *
- *   Ignored if [iconImage] is not specified.
- *
- *   **Note**: This property is not supported on native platforms, yet.
- *
- * @param iconIgnorePlacement
- *   If true, other symbols can be visible even if they collide with the icon.
- *
- *   Ignored if [iconImage] is not specified.
- *
- * @param iconOptional
- *   If true, text will display without their corresponding icons when the icon collides with other
- *   symbols and the text does not.
- *
- *   Ignored if not both [iconImage] and [textField] are specified.
- *
- * @param iconRotationAlignment
- *   In combination with [placement], determines the rotation behavior of icons.
- *   See [IconRotationAlignment].
- *
- *   Ignored if [iconImage] is not specified.
- *
- * @param iconSize
- *   Scales the original size of the icon by the provided factor. The new pixel size of the image
- *   will be the original pixel size multiplied by [iconSize]. 1 is the original size; 3 triples the
- *   size of the image.
- *
- *   Ignored if [iconImage] is not specified.
- *
- * @param iconTextFit
- *   Scales the icon to fit around the associated text. See [IconTextFit].
- *
- *   Ignored if not both [iconImage] and [textField] are specified.
- *
- * @param iconTextFitPadding
- *   Size of the additional area added to dimensions determined by [iconTextFit].
- *
- *   Only applicable when if [iconTextFit] is not [IconTextFit.None].
- *   Ignored if not both [iconImage] and [textField] are specified.
- *
  * @param iconImage
  *   Image to use for drawing an image background.
- *
- * @param iconRotate
- *   Rotates the icon clockwise by the number in degrees.
- *
- *   Ignored if [iconImage] is not specified.
- *
- * @param iconPadding
- *   Size of additional area round the icon bounding box used for detecting symbol collisions.
- *
- *   Ignored if [iconImage] is not specified.
- *
- * @param iconKeepUpright
- *   If true, the icon may be flipped to prevent it from being rendered upside-down.
- *
- *   Only applicable if [iconRotationAlignment] is [IconRotationAlignment.Map] and [placement] is
- *   either [SymbolPlacement.Line] or [SymbolPlacement.LineCenter].
- *
- *   Ignored if [iconImage] is not specified.
- *
- * @param iconOffset
- *   Offset distance of icon from its anchor. Positive values indicate right and down, while
- *   negative values indicate left and up. Each component is multiplied by the value of [iconSize]
- *   to obtain the final offset in dp. When combined with [iconRotate] the offset will be as if the
- *   rotated direction was up.
- *
- *   Ignored if [iconImage] is not specified.
- *
- * @param iconAnchor
- *   Part of the icon placed closest to the anchor. See [SymbolAnchor].
- *
- *   Ignored if [iconImage] is not specified.
- *
- * @param iconPitchAlignment
- *   Orientation of icon when map is pitched. See [IconPitchAlignment].
- *
- *   Ignored if [iconImage] is not specified.
  *
  * @param iconOpacity
  *   The opacity at which the icon will be drawn. A value in the range `[0..1]`.
@@ -184,6 +101,90 @@ import androidx.compose.runtime.key as composeKey
  *
  *   Ignored if [iconImage] is not specified.
  *
+ * @param iconSize
+ *   Scales the original size of the icon by the provided factor. The new pixel size of the image
+ *   will be the original pixel size multiplied by [iconSize]. 1 is the original size; 3 triples the
+ *   size of the image.
+ *
+ *   Ignored if [iconImage] is not specified.
+ *
+ * @param iconRotationAlignment
+ *   In combination with [placement], determines the rotation behavior of icons.
+ *   See [IconRotationAlignment].
+ *
+ *   Ignored if [iconImage] is not specified.
+ *
+ * @param iconPitchAlignment
+ *   Orientation of icon when map is pitched. See [IconPitchAlignment].
+ *
+ *   Ignored if [iconImage] is not specified.
+ *
+ * @param iconTextFit
+ *   Scales the icon to fit around the associated text. See [IconTextFit].
+ *
+ *   Ignored if not both [iconImage] and [textField] are specified.
+ *
+ * @param iconTextFitPadding
+ *   Size of the additional area added to dimensions determined by [iconTextFit].
+ *
+ *   Only applicable when if [iconTextFit] is not [IconTextFit.None].
+ *   Ignored if not both [iconImage] and [textField] are specified.
+ *
+ * @param iconKeepUpright
+ *   If true, the icon may be flipped to prevent it from being rendered upside-down.
+ *
+ *   Only applicable if [iconRotationAlignment] is [IconRotationAlignment.Map] and [placement] is
+ *   either [SymbolPlacement.Line] or [SymbolPlacement.LineCenter].
+ *
+ *   Ignored if [iconImage] is not specified.
+ *
+ * @param iconRotate
+ *   Rotates the icon clockwise by the number in degrees.
+ *
+ *   Ignored if [iconImage] is not specified.
+ *
+ * @param iconAnchor
+ *   Part of the icon placed closest to the anchor. See [SymbolAnchor].
+ *
+ *   Ignored if [iconImage] is not specified.
+ *
+ * @param iconOffset
+ *   Offset distance of icon from its anchor. Positive values indicate right and down, while
+ *   negative values indicate left and up. Each component is multiplied by the value of [iconSize]
+ *   to obtain the final offset in dp. When combined with [iconRotate] the offset will be as if the
+ *   rotated direction was up.
+ *
+ *   Ignored if [iconImage] is not specified.
+ *
+ * @param iconPadding
+ *   Size of additional area round the icon bounding box used for detecting symbol collisions.
+ *
+ *   Ignored if [iconImage] is not specified.
+ *
+ * @param iconAllowOverlap
+ *   If true, the icon will be visible even if it collides with other previously drawn symbols.
+ *
+ *   Ignored if [iconImage] is not specified, overridden by [iconOverlap], if specified.
+ *
+ * @param iconOverlap
+ *   Controls whether to show an icon when it overlaps other symbols on the map.
+ *   See [SymbolOverlap].
+ *
+ *   Ignored if [iconImage] is not specified.
+ *
+ *   **Note**: This property is not supported on native platforms, yet.
+ *
+ * @param iconIgnorePlacement
+ *   If true, other symbols can be visible even if they collide with the icon.
+ *
+ *   Ignored if [iconImage] is not specified.
+ *
+ * @param iconOptional
+ *   If true, text will display without their corresponding icons when the icon collides with other
+ *   symbols and the text does not.
+ *
+ *   Ignored if not both [iconImage] and [textField] are specified.
+ *
  * @param iconTranslate
  *   The geometry's offset relative to the [iconTranslateAnchor]. Negative numbers indicate left
  *   and up, respectively.
@@ -195,8 +196,45 @@ import androidx.compose.runtime.key as composeKey
  *
  *   Ignored if [iconTranslate] is not set.
  *
- * @param textPitchAlignment
- *   Orientation of text when map is pitched. See [TextPitchAlignment].
+ * @param textField
+ *   Value to use for a text label. If a plain string is provided, it will be treated as a formatted
+ *   with default/inherited formatting options.
+ *
+ * @param textOpacity
+ *   The opacity at which the text will be drawn.
+ *
+ *   Ignored if [textField] is not specified.
+ *
+ * @param textColor
+ *   The color with which the text will be drawn.
+ *
+ *   Ignored if [textField] is not specified.
+ *
+ * @param textHaloColor
+ *   The color of the text's halo, which helps it stand out from backgrounds.
+ *
+ *   Ignored if [textField] is not specified.
+ *
+ * @param textHaloBlur
+ *   The halo's fadeout distance towards the outside in dp.
+ *
+ *   Ignored if [textField] is not specified.
+ *
+ * @param textFont
+ *   Font stack to use for displaying text.
+ *
+ *   Ignored if [textField] is not specified.
+ *
+ * @param textSize
+ *   Font size in dp.
+ *
+ *   Ignored if [textField] is not specified.
+ *
+ * @param textTransform
+ *   Specifies how to capitalize text. See [TextTransform].
+ *
+ * @param textLetterSpacing
+ *   Text tracking amount in ems.
  *
  *   Ignored if [textField] is not specified.
  *
@@ -206,17 +244,15 @@ import androidx.compose.runtime.key as composeKey
  *
  *   Ignored if [textField] is not specified.
  *
- * @param textField
- *   Value to use for a text label. If a plain string is provided, it will be treated as a formatted
- *   with default/inherited formatting options.
- *
- * @param textFont
- *   Font stack to use for displaying text.
+ * @param textPitchAlignment
+ *   Orientation of text when map is pitched. See [TextPitchAlignment].
  *
  *   Ignored if [textField] is not specified.
  *
- * @param textSize
- *   Font size in dp.
+ * @param textMaxAngle
+ *   Maximum angle change in degrees between adjacent characters.
+ *
+ *   Only applicable if [placement] is [SymbolPlacement.Line] or [SymbolPlacement.LineCenter]
  *
  *   Ignored if [textField] is not specified.
  *
@@ -230,19 +266,47 @@ import androidx.compose.runtime.key as composeKey
  *
  *   Ignored if [textField] is not specified.
  *
- * @param textLetterSpacing
- *   Text tracking amount in ems.
- *
- *   Ignored if [textField] is not specified.
- *
  * @param textJustify
  *   Text justification options. See [TextJustify].
  *
  *   Ignored if [textField] is not specified.
  *
- * @param textRadialOffset
- *   Radial offset of text, in the direction of the symbol's anchor. Useful in combination with
- *   [textVariableAnchor], which defaults to using the two-dimensional [textOffset] if present.
+ * @param textWritingMode
+ *   The property allows control over a symbol's orientation. Note that the property values act as a
+ *   hint, so that a symbol whose language doesn’t support the provided orientation will be laid out
+ *   in its natural orientation. Example: English point symbol will be rendered horizontally even if
+ *   array value contains single 'vertical' enum value. The order of elements in an array define
+ *   priority order for the placement of an orientation variant. See [TextWritingMode]
+ *
+ *   Ignored if [textField] is not specified.
+ *
+ * @param textKeepUpright
+ *   If true, the text may be flipped vertically to prevent it from being rendered upside-down.
+ *
+ *   Only applicable if [textRotationAlignment] is [TextRotationAlignment.Map] and
+ *   [placement] is [SymbolPlacement.Line] or [SymbolPlacement.LineCenter]
+ *
+ *   Ignored if [textField] is not specified.
+ *
+ * @param textRotate
+ *   Rotates the text clockwise. Unit in degrees.
+ *
+ *   Ignored if [textField] is not specified.
+ *
+ * @param textAnchor
+ *   Part of the text placed closest to the anchor. See [SymbolAnchor].
+ *
+ *   Overridden by [textVariableAnchorOffset].
+ *
+ *   Ignored if [textField] is not specified.
+ *
+ * @param textOffset
+ *   Offset distance of text from its anchor in ems. Positive values indicate right and down, while
+ *   negative values indicate left and up. If used with [textVariableAnchor], input values will be
+ *   taken as absolute values. Offsets along the x- and y-axis will be applied automatically based
+ *   on the anchor position.
+ *
+ *   Overridden by [textRadialOffset].
  *
  *   Ignored if [textField] is not specified.
  *
@@ -254,6 +318,12 @@ import androidx.compose.runtime.key as composeKey
  *   two-dimensional [textOffset].
  *
  *   Only applicable if [placement] is [SymbolPlacement.Point].
+ *
+ *   Ignored if [textField] is not specified.
+ *
+ * @param textRadialOffset
+ *   Radial offset of text, in the direction of the symbol's anchor. Useful in combination with
+ *   [textVariableAnchor], which defaults to using the two-dimensional [textOffset] if present.
  *
  *   Ignored if [textField] is not specified.
  *
@@ -284,58 +354,9 @@ import androidx.compose.runtime.key as composeKey
  *
  *   Ignored if [textField] is not specified.
  *
- * @param textAnchor
- *   Part of the text placed closest to the anchor. See [SymbolAnchor].
- *
- *   Overridden by [textVariableAnchorOffset].
- *
- *   Ignored if [textField] is not specified.
- *
- * @param textMaxAngle
- *   Maximum angle change in degrees between adjacent characters.
- *
- *   Only applicable if [placement] is [SymbolPlacement.Line] or [SymbolPlacement.LineCenter]
- *
- *   Ignored if [textField] is not specified.
- *
- * @param textWritingMode
- *   The property allows control over a symbol's orientation. Note that the property values act as a
- *   hint, so that a symbol whose language doesn’t support the provided orientation will be laid out
- *   in its natural orientation. Example: English point symbol will be rendered horizontally even if
- *   array value contains single 'vertical' enum value. The order of elements in an array define
- *   priority order for the placement of an orientation variant. See [TextWritingMode]
- *
- *   Ignored if [textField] is not specified.
- *
- * @param textRotate
- *   Rotates the text clockwise. Unit in degrees.
- *
- *   Ignored if [textField] is not specified.
- *
  * @param textPadding
  *   Size of the additional area in dp around the text bounding box used for detecting symbol
  *   collisions.
- *
- *   Ignored if [textField] is not specified.
- *
- * @param textKeepUpright
- *   If true, the text may be flipped vertically to prevent it from being rendered upside-down.
- *
- *   Only applicable if [textRotationAlignment] is [TextRotationAlignment.Map] and
- *   [placement] is [SymbolPlacement.Line] or [SymbolPlacement.LineCenter]
- *
- *   Ignored if [textField] is not specified.
- *
- * @param textTransform
- *   Specifies how to capitalize text. See [TextTransform].
- *
- * @param textOffset
- *   Offset distance of text from its anchor in ems. Positive values indicate right and down, while
- *   negative values indicate left and up. If used with [textVariableAnchor], input values will be
- *   taken as absolute values. Offsets along the x- and y-axis will be applied automatically based
- *   on the anchor position.
- *
- *   Overridden by [textRadialOffset].
  *
  *   Ignored if [textField] is not specified.
  *
@@ -365,26 +386,6 @@ import androidx.compose.runtime.key as composeKey
  *
  *   Ignored if not both [textField] and [iconImage] are specified.
  *
- * @param textOpacity
- *   The opacity at which the text will be drawn.
- *
- *   Ignored if [textField] is not specified.
- *
- * @param textColor
- *   The color with which the text will be drawn.
- *
- *   Ignored if [textField] is not specified.
- *
- * @param textHaloColor
- *   The color of the text's halo, which helps it stand out from backgrounds.
- *
- *   Ignored if [textField] is not specified.
- *
- * @param textHaloBlur
- *   The halo's fadeout distance towards the outside in dp.
- *
- *   Ignored if [textField] is not specified.
- *
  * @param textTranslate
  *   Distance that the text's anchor is moved from its original placement in dp. Positive values
  *   indicate right and down, while negative values indicate left and up.
@@ -406,66 +407,90 @@ public inline fun SymbolLayer(
   maxZoom: Float = 24.0f,
   filter: Expression<Boolean> = nil(),
   visible: Boolean = true,
+  sortKey: Expression<Number> = nil(),
 
   placement: Expression<String> = const(SymbolPlacement.Point),
   spacing: Expression<Number> = const(250.0),
   avoidEdges: Expression<Boolean> = const(false),
-  sortKey: Expression<Number> = nil(),
   zOrder: Expression<String> = const(SymbolSortOrder.Auto),
 
-  iconAllowOverlap: Expression<Boolean> = const(false),
-  iconOverlap: Expression<String> = nil(),
-  iconIgnorePlacement: Expression<Boolean> = const(false),
-  iconOptional: Expression<Boolean> = const(false),
-  iconRotationAlignment: Expression<String> = const(IconRotationAlignment.Auto),
-  iconSize: Expression<Number> = const(1.0),
-  iconTextFit: Expression<String> = const(IconTextFit.None),
-  iconTextFitPadding: Expression<Insets> = insets(0, 0, 0, 0),
+  // icon image
   iconImage: Expression<TResolvedImage> = nil(),
-  iconRotate: Expression<Number> = const(0.0),
-  iconPadding: Expression<Number> = const(2.0),
-  iconKeepUpright: Expression<Boolean> = const(false),
-  iconOffset: Expression<Point> = point(0, 0),
-  iconAnchor: Expression<String> = const(SymbolAnchor.Center),
-  iconPitchAlignment: Expression<String> = const(IconPitchAlignment.Auto),
+
+  // icon colors
   iconOpacity: Expression<Number> = const(1.0),
   iconColor: Expression<Color> = const(Color.Black),
   iconHaloColor: Expression<Color> = const(Color.Transparent),
   iconHaloWidth: Expression<Number> = const(0.0),
   iconHaloBlur: Expression<Number> = const(0.0),
+
+  // icon layout
+  iconSize: Expression<Number> = const(1.0),
+  iconRotationAlignment: Expression<String> = const(IconRotationAlignment.Auto),
+  iconPitchAlignment: Expression<String> = const(IconPitchAlignment.Auto),
+  iconTextFit: Expression<String> = const(IconTextFit.None),
+  iconTextFitPadding: Expression<Insets> = insets(0, 0, 0, 0),
+  iconKeepUpright: Expression<Boolean> = const(false),
+  iconRotate: Expression<Number> = const(0.0),
+
+  // icon anchoring
+  iconAnchor: Expression<String> = const(SymbolAnchor.Center),
+  iconOffset: Expression<Point> = point(0, 0),
+
+  // icon collision
+  iconPadding: Expression<Number> = const(2.0),
+  iconAllowOverlap: Expression<Boolean> = const(false),
+  iconOverlap: Expression<String> = nil(),
+  iconIgnorePlacement: Expression<Boolean> = const(false),
+  iconOptional: Expression<Boolean> = const(false),
+
+  // icon translate
   iconTranslate: Expression<Point> = point(0, 0),
   iconTranslateAnchor: Expression<String> = const(TranslateAnchor.Map),
 
-  textPitchAlignment: Expression<String> = const(IconPitchAlignment.Auto),
-  textRotationAlignment: Expression<String> = const(TextRotationAlignment.Auto),
+  // text content
   textField: Expression<TFormatted> = nil(),
-  textFont: Expression<List<String>> =
-    literal(listOf(const("Open Sans Regular"), const("Arial Unicode MS Regular"))),
-  textSize: Expression<Number> = const(16.0),
-  textMaxWidth: Expression<Number> = const(10.0),
-  textLineHeight: Expression<Number> = const(1.2),
-  textLetterSpacing: Expression<Number> = const(0.0),
-  textJustify: Expression<String> = const(TextJustify.Center),
-  textRadialOffset: Expression<Number> = const(0.0),
-  textVariableAnchor: Expression<List<String>> = nil(),
-  textVariableAnchorOffset: Expression<List<Pair<String, Point>>> = nil(),
-  textAnchor: Expression<String> = const(SymbolAnchor.Center),
-  textMaxAngle: Expression<Number> = const(45.0),
-  textWritingMode: Expression<List<String>> = nil(),
-  textRotate: Expression<Number> = const(0.0),
-  textPadding: Expression<Number> = const(2.0),
-  textKeepUpright: Expression<Boolean> = const(true),
-  textTransform: Expression<String> = const(TextTransform.None),
-  textOffset: Expression<Point> = point(0, 0),
-  textAllowOverlap: Expression<Boolean> = const(false),
-  textOverlap: Expression<String> = nil(),
-  textIgnorePlacement: Expression<Boolean> = const(false),
-  textOptional: Expression<Boolean> = const(false),
+
+  // text glyph colors
   textOpacity: Expression<Number> = const(1.0),
   textColor: Expression<Color> = const(Color.Black),
   textHaloColor: Expression<Color> = const(Color.Transparent),
   textHaloWidth: Expression<Number> = const(0.0),
   textHaloBlur: Expression<Number> = const(0.0),
+
+  // text glyph properties
+  textFont: Expression<List<String>> =
+    literal(listOf(const("Open Sans Regular"), const("Arial Unicode MS Regular"))),
+  textSize: Expression<Number> = const(16.0),
+  textTransform: Expression<String> = const(TextTransform.None),
+  textLetterSpacing: Expression<Number> = const(0.0),
+  textRotationAlignment: Expression<String> = const(TextRotationAlignment.Auto),
+  textPitchAlignment: Expression<String> = const(TextPitchAlignment.Auto),
+  textMaxAngle: Expression<Number> = const(45.0),
+
+  // text paragraph layout
+  textMaxWidth: Expression<Number> = const(10.0),
+  textLineHeight: Expression<Number> = const(1.2),
+  textJustify: Expression<String> = const(TextJustify.Center),
+  textWritingMode: Expression<List<String>> = nil(),
+  textKeepUpright: Expression<Boolean> = const(true),
+  textRotate: Expression<Number> = const(0.0),
+
+  // text anchoring
+  textAnchor: Expression<String> = const(SymbolAnchor.Center),
+  textOffset: Expression<Point> = point(0, 0),
+  textVariableAnchor: Expression<List<String>> = nil(),
+  textRadialOffset: Expression<Number> = const(0.0),
+  textVariableAnchorOffset: Expression<List<Pair<String, Point>>> = nil(),
+
+  // text collision
+  textPadding: Expression<Number> = const(2.0),
+  textAllowOverlap: Expression<Boolean> = const(false),
+  textOverlap: Expression<String> = nil(),
+  textIgnorePlacement: Expression<Boolean> = const(false),
+  textOptional: Expression<Boolean> = const(false),
+
+  // text translate
   textTranslate: Expression<Point> = point(0, 0),
   textTranslateAnchor: Expression<String> = const(TranslateAnchor.Map),
 
@@ -663,7 +688,7 @@ public object IconPitchAlignment {
   /** The icon is aligned to the plane of the map. */
   public const val Map: String = "map"
 
-  /** The icon is aligned to the plane of the viewport. */
+  /** The icon is aligned to the plane of the viewport, i.e. as if glued to the screen */
   public const val Viewport: String = "viewport"
 
   /** Automatically matches the value of [IconRotationAlignment] */
@@ -675,7 +700,7 @@ public object TextPitchAlignment {
   /** The text is aligned to the plane of the map. */
   public const val Map: String = "map"
 
-  /** The text is aligned to the plane of the viewport. */
+  /** The text is aligned to the plane of the viewport, i.e. as if glued to the screen */
   public const val Viewport: String = "viewport"
 
   /** Automatically matches the value of [TextRotationAlignment] */


### PR DESCRIPTION
to be more consistent. The order:
1. common properties (sortKey, translate, opacity, ...)
2. colors (color, pattern, gradients, ...)
3. defining shapes (radius, strokes, outlines, heights)
4. layer specifics

For the symbol layer, also
1. common properties
2. symbol properties,
3. icon properties
4. text properties

The icon and text properties are sorted in a consistent manner:
1. content (image / text)
2. colors
3. layout
4. anchoring
5. collision
6. translate

---

I hereby contribute this under the terms of the BSD license.